### PR TITLE
Create gpm.is-an.app

### DIFF
--- a/domains/gpm.is-an.app
+++ b/domains/gpm.is-an.app
@@ -1,0 +1,13 @@
+{
+  "$schema": "../schemas/domain.schema.json",
+  "description": "Server for the Bash Package Manager called CPM (short for Cool Package Manager)",
+  "domain": "is-an.app",
+  "subdomain": "cpm",
+  "owner": {
+    "email": "sevenworks@goatmail.uk"
+  },
+  "record": {
+    "CNAME": "78c6302c-038d-4092-a570-512ae88543d1.id.repl.co"
+  },
+  "proxy": false
+}


### PR DESCRIPTION
I plan on using the cpm.is-an.app as a host for packages installable by CPM. My plan is to create a better, faster package manager written in Bash.

### Link to Website

Link: https://cpmpkg.jscraft.repl.co